### PR TITLE
Fix docker compile for wsl2

### DIFF
--- a/client/src/archetypePropertiesExplorer.ts
+++ b/client/src/archetypePropertiesExplorer.ts
@@ -223,7 +223,7 @@ export class ArchetypeNodeProvider implements vscode.TreeDataProvider<ArchetypeI
 			if (archetypeMode == 'binary' || archetypeMode == 'docker') {
 				let fsPath = vscode.window.activeTextEditor.document.uri.fsPath;
 				const archetype_bin = config.get('archetypeBin');
-				const cwd = process.cwd();
+				const cwd = vscode.workspace.workspaceFolders[0].uri.fsPath
 				const bin = archetypeMode == 'binary' ? archetype_bin : `docker run --rm -v ${cwd}:${cwd} -w ${cwd} completium/archetype:latest`;
 				let cmd = bin + ' --service get_properties ' + fsPath;
 				let cp = require('child_process');

--- a/client/src/commands.ts
+++ b/client/src/commands.ts
@@ -38,7 +38,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
 			if (archetypeMode == 'binary' || archetypeMode == 'docker') {
 				let cp = require('child_process');
 				const archetype_bin = config.get('archetypeBin');
-				const cwd = process.cwd();
+				const cwd = vscode.workspace.workspaceFolders[0].uri.fsPath
 				const bin = archetypeMode == 'binary' ? archetype_bin : `docker run --rm -v ${cwd}:${cwd} -w ${cwd} completium/archetype:latest`;
 				let cmd = bin + ' --set-caller-init=' + caller + ' -t ' + target + ' ' + fsPath + ' > ' + outputFsPath;
 				cp.exec(cmd, cb);
@@ -95,7 +95,7 @@ export function registerCommands(context: vscode.ExtensionContext) {
 			if (archetypeMode == 'binary' || archetypeMode == 'docker') {
 				let cp = require('child_process');
 				const archetype_bin = config.get('archetypeBin');
-				const cwd = process.cwd();
+				const cwd = vscode.workspace.workspaceFolders[0].uri.fsPath
 				const bin = archetypeMode == 'binary' ? archetype_bin : `docker run --rm -v ${cwd}:${cwd} -w ${cwd} completium/archetype:latest`;
 				let cmd = bin + ' -d ' + fsPath + ' > ' + outputFsPath;
 				cp.exec(cmd, (_err: string, stdout: string, stderr: string) => {


### PR DESCRIPTION
Testing with wsl2 was presenting failure when
compiling with docker due to the 'cwd' process folder. The code was taking the VSCode process dir instead, which was a windows path unrelated to the workspace. With this modification, the container can properly find the contract to be compiled, using the proper path.

I offer this pull request as a suggestion, as it worked for me. I did not extensively test this. I could successfully obtain the compiled .tz contract.